### PR TITLE
feat: keybind for formatting page

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -66,6 +66,7 @@ export default class ObsidianPrettier extends Plugin {
 		this.addCommand({
 			id: 'format-page',
 			name: 'Format Page',
+			hotkeys: [{ modifiers: ['Ctrl', 'Shift'], key: 'I' }],
 			editorCallback: async (editor: Editor, _ctx: MarkdownView | MarkdownFileInfo) =>
 				editor.setValue(await formatText(editor.getValue(), this.settings)),
 		});


### PR DESCRIPTION
Bind the format page command to 'Ctrl + Shift + I'. That combination is already used by VS Code, so should be the most commonly used. 